### PR TITLE
Patch 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deby"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["ink8bit <ink8bit@users.noreply.github.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ It should be a valid JSON file and contain the following fields:
 
 ```json
 {
-  "package": "package name",
   "changelog": {
     "update": true,
+    "package": "changelog package name",
     "distribution": "unstable",
     "urgency": "low",
     "maintainer": {
@@ -87,6 +87,7 @@ It should be a valid JSON file and contain the following fields:
       }
     },
     "binaryControl": {
+      "package": "binary package name",
       "description": "description",
       "section": "section",
       "priority": "optional",

--- a/README.md
+++ b/README.md
@@ -22,11 +22,34 @@ deby = { git = "https://github.com/ink8bit/deby", branch = "main" }
 // provide required arguments
 let version = "1.0.0";
 let changes = "some changes";
-// if you want to provide additional fields - separate them with `;` or just put an empty string
-let additional_fields = "Some-Field: A;Another-Field: B";
 
-if let Err(e) = deby::update(version, changes, additional_fields) {
-    panic!("{}", e);
+// if you want to provide additional fields - separate them with `;` or just put an empty string
+let user_defined_fields: Vec<&str> = vec!["Some-Field: A", "Another-Field: B"];
+
+match deby::update(version, changes, user_defined_fields) {
+    Ok(msg) => {
+        println!("{}", msg.0);
+        println!("{}", msg.1);
+    }
+    Err(e) => panic!("{}", e),
+}
+```
+
+If you want to update *control* and *changelog* files separately, you should use two public functions:
+
+```rust
+let version = "1.0.0";
+let changes = "changes:\nline1\nline2\nline3";
+let user_defined_fields: Vec<&str> = vec!["Some-Field: A", "Another-Field: B"];
+
+match deby::update_changelog_file(version, changes) {
+    Ok(msg) => println!("{}", msg),
+    Err(e) => panic!("{}", e),
+}
+
+match deby::update_control_file(user_defined_fields) {
+    Ok(msg) => println!("{}", msg),
+    Err(e) => panic!("{}", e),
 }
 ```
 
@@ -39,14 +62,14 @@ It should be a valid JSON file and contain the following fields:
 ```json
 {
   "package": "package name",
-  "maintainer": {
-    "email": "user@example.com",
-    "name": "username"
-  },
   "changelog": {
     "update": true,
     "distribution": "unstable",
-    "urgency": "low"
+    "urgency": "low",
+    "maintainer": {
+      "name": "maintainer name",
+      "email": "maintainer email"
+    }
   },
   "control": {
     "update": true,
@@ -57,7 +80,11 @@ It should be a valid JSON file and contain the following fields:
       "buildDepends": "depends",
       "standardsVersion": "1.2.3",
       "homepage": "url",
-      "vcsBrowser": "url"
+      "vcsBrowser": "url",
+      "maintainer": {
+        "name": "maintainer name",
+        "email": "maintainer email"
+      }
     },
     "binaryControl": {
       "description": "description",

--- a/src/config/changelog.rs
+++ b/src/config/changelog.rs
@@ -11,6 +11,7 @@ use super::{Config, Maintainer};
 #[derive(Deserialize, Debug)]
 pub(crate) struct Changelog {
     update: bool,
+    package: String,
     #[serde(default = "Changelog::default_distribution")]
     distribution: Distribution,
     #[serde(default = "Changelog::default_urgency")]
@@ -50,7 +51,7 @@ impl Changelog {
 -- {name} <{email}>  {date}
 
 {current}",
-            package = config.package,
+            package = config.changelog.package,
             email = config.changelog.maintainer.email,
             name = config.changelog.maintainer.name,
             distribution = config.changelog.distribution,
@@ -69,6 +70,7 @@ impl Changelog {
     pub(crate) fn default() -> Self {
         Self {
             update: false,
+            package: "no package name provided".to_string(),
             distribution: Distribution::Unstable,
             urgency: Urgency::Low,
             maintainer: Maintainer {

--- a/src/config/changelog.rs
+++ b/src/config/changelog.rs
@@ -6,7 +6,7 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::{error::Error, fs};
 
-use super::Config;
+use super::{Config, Maintainer};
 
 #[derive(Deserialize, Debug)]
 pub(crate) struct Changelog {
@@ -15,6 +15,7 @@ pub(crate) struct Changelog {
     distribution: Distribution,
     #[serde(default = "Changelog::default_urgency")]
     urgency: Urgency,
+    maintainer: Maintainer,
 }
 
 impl Changelog {
@@ -50,8 +51,8 @@ impl Changelog {
 
 {current}",
             package = config.package,
-            email = config.maintainer.email,
-            name = config.maintainer.name,
+            email = config.changelog.maintainer.email,
+            name = config.changelog.maintainer.name,
             distribution = config.changelog.distribution,
             urgency = config.changelog.urgency,
             current = current,
@@ -70,6 +71,10 @@ impl Changelog {
             update: false,
             distribution: Distribution::Unstable,
             urgency: Urgency::Low,
+            maintainer: Maintainer {
+                name: "no maintainer name provided".to_string(),
+                email: "no maintainer email provided".to_string(),
+            },
         }
     }
 

--- a/src/config/changelog.rs
+++ b/src/config/changelog.rs
@@ -33,7 +33,7 @@ impl Changelog {
             .create(true)
             .write(true)
             .open("debian/changelog")?;
-        let current = fs::read_to_string("debian/changelog")?;
+        let current_file = fs::read_to_string("debian/changelog")?;
 
         let dt = Utc::now().to_rfc2822();
 
@@ -56,7 +56,7 @@ impl Changelog {
             name = config.changelog.maintainer.name,
             distribution = config.changelog.distribution,
             urgency = config.changelog.urgency,
-            current = current,
+            current = current_file,
             date = dt,
             version = version,
             changes = changes_list.trim(),

--- a/src/config/control.rs
+++ b/src/config/control.rs
@@ -62,7 +62,7 @@ Description: {description}
             standards_version = config.control.source_control.standards_version,
             homepage = config.control.source_control.homepage,
             vcs_browser = config.control.source_control.vcs_browser,
-            package = config.package,
+            package = config.control.binary_control.package,
             section = config.control.binary_control.section,
             binary_priority = config.control.binary_control.priority,
             pre_depends = config.control.binary_control.pre_depends,
@@ -93,6 +93,7 @@ Description: {description}
                 vcs_browser: "no vcs browser value provided".to_string(),
             },
             binary_control: BinaryControl {
+                package: "no package name provided".to_string(),
                 description: "no description value provided".to_string(),
                 section: "no section value provided".to_string(),
                 priority: Priority::Optional,
@@ -148,6 +149,7 @@ impl Display for Priority {
 
 #[derive(Deserialize, Debug)]
 struct BinaryControl {
+    package: String,
     description: String,
     section: String,
     priority: Priority,

--- a/src/config/control.rs
+++ b/src/config/control.rs
@@ -18,7 +18,7 @@ pub(crate) struct Control {
 impl Control {
     pub(crate) fn update<'a>(
         config: &Config,
-        user_defined_fields: &str,
+        user_defined_fields: Vec<&str>,
     ) -> Result<&'a str, DebyError> {
         if !config.control.update {
             return Ok("debian/control file not updated due to config file setting.");
@@ -31,7 +31,7 @@ impl Control {
             .map_err(|_| DebyError::ControlOpen)?;
 
         let mut additional = String::new();
-        for field in user_defined_fields.split(';') {
+        for field in user_defined_fields {
             additional.push_str(&format!("{}\n", field));
         }
 

--- a/src/config/control.rs
+++ b/src/config/control.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 use std::fs::OpenOptions;
 use std::io::Write;
 
-use super::Config;
+use super::{Config, Maintainer};
 
 #[derive(Deserialize, Debug)]
 pub(crate) struct Control {
@@ -56,8 +56,8 @@ Description: {description}
 ",
             source = config.control.source_control.source,
             source_priority = config.control.source_control.priority,
-            name = config.maintainer.name,
-            email = config.maintainer.email,
+            name = config.control.source_control.maintainer.name,
+            email = config.control.source_control.maintainer.email,
             build_depends = config.control.source_control.build_depends,
             standards_version = config.control.source_control.standards_version,
             homepage = config.control.source_control.homepage,
@@ -81,6 +81,10 @@ Description: {description}
             update: false,
             source_control: SourceControl {
                 source: "no source value provided".to_string(),
+                maintainer: Maintainer {
+                    name: "no maintainer name provided".to_string(),
+                    email: "no maintainer email provided".to_string(),
+                },
                 section: "no section value provided".to_string(),
                 priority: Priority::Optional,
                 build_depends: "no build depends value provided".to_string(),
@@ -155,6 +159,7 @@ struct BinaryControl {
 #[derive(Deserialize, Debug)]
 struct SourceControl {
     source: String,
+    maintainer: Maintainer,
     section: String,
     priority: Priority,
     #[serde(rename(deserialize = "buildDepends"))]

--- a/src/config/control.rs
+++ b/src/config/control.rs
@@ -19,7 +19,6 @@ pub(crate) struct Control {
 impl Control {
     pub(crate) fn update<'a>(
         config: &Config,
-        version: &str,
         user_defined_fields: &str,
     ) -> Result<&'a str, Box<dyn Error>> {
         if !config.control.update {
@@ -39,6 +38,7 @@ impl Control {
         let contents = format!(
             "
 Source: {source}
+Section: {source_section}
 Priority: {source_priority}
 Maintainer: {name} <{email}>
 Build-Depends: {build_depends}
@@ -47,7 +47,7 @@ Homepage: {homepage}
 Vcs-Browser: {vcs_browser}
 
 Package: {package}
-Section: {section}
+Section: {binary_section}
 Priority: {binary_priority}
 Pre-Depends: {pre_depends}
 Architecture: {arch}
@@ -55,6 +55,7 @@ Description: {description}
 {additional}
 ",
             source = config.control.source_control.source,
+            source_section = config.control.source_control.section,
             source_priority = config.control.source_control.priority,
             name = config.control.source_control.maintainer.name,
             email = config.control.source_control.maintainer.email,
@@ -63,7 +64,7 @@ Description: {description}
             homepage = config.control.source_control.homepage,
             vcs_browser = config.control.source_control.vcs_browser,
             package = config.control.binary_control.package,
-            section = config.control.binary_control.section,
+            binary_section = config.control.binary_control.section,
             binary_priority = config.control.binary_control.priority,
             pre_depends = config.control.binary_control.pre_depends,
             arch = config.control.binary_control.architecture,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -63,7 +63,7 @@ impl Config {
             Err(e) => panic!("{}", e),
         };
 
-        match Control::update(&self, &version, &user_defined_fields) {
+        match Control::update(&self, &user_defined_fields) {
             Ok(msg) => println!("{}", msg),
             Err(e) => panic!("{}", e),
         };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,7 +17,6 @@ struct Maintainer {
 
 #[derive(Deserialize, Debug)]
 pub(crate) struct Config {
-    package: String,
     #[serde(default = "Changelog::default")]
     changelog: Changelog,
     #[serde(default = "Control::default")]
@@ -30,7 +29,6 @@ impl Config {
     pub(crate) fn new() -> Result<Self, Box<dyn Error>> {
         let config = Self::parse()?;
         Ok(Self {
-            package: config.package,
             changelog: config.changelog,
             control: config.control,
         })

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,7 +17,6 @@ struct Maintainer {
 
 #[derive(Deserialize, Debug)]
 pub(crate) struct Config {
-    maintainer: Maintainer,
     package: String,
     #[serde(default = "Changelog::default")]
     changelog: Changelog,
@@ -32,7 +31,6 @@ impl Config {
         let config = Self::parse()?;
         Ok(Self {
             package: config.package,
-            maintainer: config.maintainer,
             changelog: config.changelog,
             control: config.control,
         })

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -109,4 +109,26 @@ impl Config {
 
         Ok(msg)
     }
+
+    pub(crate) fn update_control(&self, user_defined_fields: Vec<&str>) -> Result<&str, DebyError> {
+        if !Path::new("debian").exists() {
+            fs::create_dir("debian").map_err(|_| DebyError::DebianDir)?;
+        }
+
+        let msg =
+            Control::update(&self, user_defined_fields).map_err(|_| DebyError::ControlUpdate)?;
+
+        Ok(msg)
+    }
+
+    pub(crate) fn update_changelog(&self, version: &str, changes: &str) -> Result<&str, DebyError> {
+        if !Path::new("debian").exists() {
+            fs::create_dir("debian").map_err(|_| DebyError::DebianDir)?;
+        }
+
+        let msg =
+            Changelog::update(&self, &version, &changes).map_err(|_| DebyError::ChangelogUpdate)?;
+
+        Ok(msg)
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -93,7 +93,7 @@ impl Config {
         &self,
         version: &str,
         changes: &str,
-        user_defined_fields: &str,
+        user_defined_fields: Vec<&str>,
     ) -> Result<(&str, &str), DebyError> {
         if !Path::new("debian").exists() {
             fs::create_dir("debian").map_err(|_| DebyError::DebianDir)?;
@@ -103,7 +103,7 @@ impl Config {
             Changelog::update(&self, &version, &changes).map_err(|_| DebyError::ChangelogUpdate)?;
 
         let control_msg =
-            Control::update(&self, &user_defined_fields).map_err(|_| DebyError::ControlUpdate)?;
+            Control::update(&self, user_defined_fields).map_err(|_| DebyError::ControlUpdate)?;
 
         let msg = (changelog_msg, control_msg);
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -94,19 +94,19 @@ impl Config {
         version: &str,
         changes: &str,
         user_defined_fields: &str,
-    ) -> Result<(), DebyError> {
+    ) -> Result<(&str, &str), DebyError> {
         if !Path::new("debian").exists() {
             fs::create_dir("debian").map_err(|_| DebyError::DebianDir)?;
         }
 
         let changelog_msg =
             Changelog::update(&self, &version, &changes).map_err(|_| DebyError::ChangelogUpdate)?;
-        println!("{}", changelog_msg);
 
         let control_msg =
             Control::update(&self, &user_defined_fields).map_err(|_| DebyError::ControlUpdate)?;
-        println!("{}", control_msg);
 
-        Ok(())
+        let msg = (changelog_msg, control_msg);
+
+        Ok(msg)
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,13 +1,59 @@
 use serde::Deserialize;
 
+use std::fmt;
+use std::fs;
 use std::path::Path;
-use std::{error::Error, fs};
 
 mod changelog;
 mod control;
 
 use changelog::Changelog;
 use control::Control;
+
+#[derive(Debug)]
+pub enum DebyError {
+    ConfigParse,
+    ConfigNew,
+    Update,
+    ConfigRead,
+    Deserialize,
+    DebianDir,
+    ChangelogUpdate,
+    ChangelogOpen,
+    ChangelogRead,
+    ChangelogWrite,
+    ControlUpdate,
+    ControlOpen,
+    ControlWrite,
+}
+
+impl fmt::Display for DebyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            DebyError::ConfigNew => {
+                write!(f, "Could not create configuration from config file .debyrc")
+            }
+            DebyError::ConfigParse => write!(f, "Could not parse config file .debyrc"),
+            DebyError::ConfigRead => write!(f, "No config file .debyrc found"),
+
+            DebyError::Update => write!(f, "Could not update your files"),
+            DebyError::Deserialize => write!(f, "Could not deserialize .debyrc config file"),
+            DebyError::DebianDir => write!(
+                f,
+                "No directory with `debian` name found in the root of the project"
+            ),
+
+            DebyError::ChangelogUpdate => write!(f, "Could not update debian changelog file"),
+            DebyError::ChangelogOpen => write!(f, "Could not open debian changelog file"),
+            DebyError::ChangelogRead => write!(f, "Could not read debian changelog file"),
+            DebyError::ChangelogWrite => write!(f, "Could not update debian changelog file"),
+
+            DebyError::ControlUpdate => write!(f, "Could not update debian control file"),
+            DebyError::ControlOpen => write!(f, "Could not open debian control file"),
+            DebyError::ControlWrite => write!(f, "Could not update debian control file"),
+        }
+    }
+}
 
 #[derive(Deserialize, Debug)]
 struct Maintainer {
@@ -26,25 +72,20 @@ pub(crate) struct Config {
 const CONFIG_FILE: &str = ".debyrc";
 
 impl Config {
-    pub(crate) fn new() -> Result<Self, Box<dyn Error>> {
-        let config = Self::parse()?;
+    pub(crate) fn new() -> Result<Self, DebyError> {
+        let config = Self::parse().map_err(|_| DebyError::ConfigParse)?;
+
         Ok(Self {
             changelog: config.changelog,
             control: config.control,
         })
     }
 
-    fn parse() -> Result<Config, Box<dyn Error>> {
-        let config_data = match fs::read_to_string(CONFIG_FILE) {
-            Ok(data) => data,
-            Err(_) => {
-                panic!(
-                    "No config file provided. Create {} file in your project root.",
-                    CONFIG_FILE
-                )
-            }
-        };
-        let config: Config = serde_json::from_str(&config_data)?;
+    fn parse() -> Result<Config, DebyError> {
+        let config_data = fs::read_to_string(CONFIG_FILE).map_err(|_| DebyError::ConfigRead)?;
+        let config: Config =
+            serde_json::from_str(&config_data).map_err(|_| DebyError::Deserialize)?;
+
         Ok(config)
     }
 
@@ -53,20 +94,18 @@ impl Config {
         version: &str,
         changes: &str,
         user_defined_fields: &str,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<(), DebyError> {
         if !Path::new("debian").exists() {
-            fs::create_dir("debian")?;
+            fs::create_dir("debian").map_err(|_| DebyError::DebianDir)?;
         }
 
-        match Changelog::update(&self, &version, &changes) {
-            Ok(msg) => println!("{}", msg),
-            Err(e) => panic!("{}", e),
-        };
+        let changelog_msg =
+            Changelog::update(&self, &version, &changes).map_err(|_| DebyError::ChangelogUpdate)?;
+        println!("{}", changelog_msg);
 
-        match Control::update(&self, &user_defined_fields) {
-            Ok(msg) => println!("{}", msg),
-            Err(e) => panic!("{}", e),
-        };
+        let control_msg =
+            Control::update(&self, &user_defined_fields).map_err(|_| DebyError::ControlUpdate)?;
+        println!("{}", control_msg);
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,13 @@ mod config;
 use config::Config;
 use std::error::Error;
 
+/// Updates `changelog` and `control` files
+///
+/// ## Arguments
+///
+/// - `version` - an updated version string
+/// - `changes` - changes to be included in your files
+/// - `user_defined_fields` - additional dynamic fields to be included in `control` file
 pub fn update(
     version: &str,
     changes: &str,
@@ -12,6 +19,7 @@ pub fn update(
         Ok(c) => c,
         Err(e) => panic!("{}", e),
     };
+
     config.update(version, changes, user_defined_fields)?;
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,13 +13,6 @@ pub fn update(
         Err(e) => panic!("{}", e),
     };
     config.update(version, changes, user_defined_fields)?;
-    Ok(())
-}
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        todo!();
-    }
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,34 @@ pub fn update(
 
     Ok((changelog_msg.to_string(), control_msg.to_string()))
 }
+
+/// Updates debian control file
+///
+/// ## Arguments
+///
+/// - `user_defined_fields` - dynamic fields to be included in binary section of control file
+pub fn update_control_file(user_defined_fields: Vec<&str>) -> Result<String, DebyError> {
+    let config = Config::new().map_err(|_| DebyError::ConfigNew)?;
+
+    let msg = config
+        .update_control(user_defined_fields)
+        .map_err(|_| DebyError::ControlUpdate)?;
+
+    Ok(msg.to_string())
+}
+
+/// Updates debian changelog file
+///
+/// ## Arguments
+///
+/// - `version` - version string to be included in changelog file
+/// - `changes` - changes to be included in changelog file
+pub fn update_changelog_file(version: &str, changes: &str) -> Result<String, DebyError> {
+    let config = Config::new().map_err(|_| DebyError::ConfigNew)?;
+
+    let msg = config
+        .update_changelog(&version, &changes)
+        .map_err(|_| DebyError::ChangelogUpdate)?;
+
+    Ok(msg.to_string())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 mod config;
 
-use config::Config;
-use std::error::Error;
+use config::{Config, DebyError};
 
 /// Updates `changelog` and `control` files
 ///
@@ -10,17 +9,12 @@ use std::error::Error;
 /// - `version` - an updated version string
 /// - `changes` - changes to be included in your files
 /// - `user_defined_fields` - additional dynamic fields to be included in `control` file
-pub fn update(
-    version: &str,
-    changes: &str,
-    user_defined_fields: &str,
-) -> Result<(), Box<dyn Error>> {
-    let config = match Config::new() {
-        Ok(c) => c,
-        Err(e) => panic!("{}", e),
-    };
+pub fn update(version: &str, changes: &str, user_defined_fields: &str) -> Result<(), DebyError> {
+    let config = Config::new().map_err(|_| DebyError::ConfigNew)?;
 
-    config.update(version, changes, user_defined_fields)?;
+    config
+        .update(version, changes, user_defined_fields)
+        .map_err(|_| DebyError::Update)?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use config::{Config, DebyError};
 pub fn update(
     version: &str,
     changes: &str,
-    user_defined_fields: &str,
+    user_defined_fields: Vec<&str>,
 ) -> Result<(String, String), DebyError> {
     let config = Config::new().map_err(|_| DebyError::ConfigNew)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,18 @@ use config::{Config, DebyError};
 /// - `version` - an updated version string
 /// - `changes` - changes to be included in your files
 /// - `user_defined_fields` - additional dynamic fields to be included in `control` file
-pub fn update(version: &str, changes: &str, user_defined_fields: &str) -> Result<(), DebyError> {
+pub fn update(
+    version: &str,
+    changes: &str,
+    user_defined_fields: &str,
+) -> Result<(String, String), DebyError> {
     let config = Config::new().map_err(|_| DebyError::ConfigNew)?;
 
-    config
+    let msg = config
         .update(version, changes, user_defined_fields)
         .map_err(|_| DebyError::Update)?;
 
-    Ok(())
+    let (changelog_msg, control_msg) = msg;
+
+    Ok((changelog_msg.to_string(), control_msg.to_string()))
 }


### PR DESCRIPTION
# Changes

- Fixed _clippy_ warnings
- Improved public API:
  - use vector for user defined fields
  - return `lib` messages instead of printing to stdout
- Added custom errors
- Config:
  - separate fields for maintainer value
  - added `section` property to source control fields 